### PR TITLE
Add QR style editor to web app

### DIFF
--- a/shared/qr.ts
+++ b/shared/qr.ts
@@ -2,11 +2,15 @@ export type QrType = 'url' | 'text' | 'wifi' | 'email' | 'phone' | 'sms';
 
 export type ErrorCorrectionLevel = 'L' | 'M' | 'Q' | 'H';
 
-export const ECL_OPTIONS: {value: ErrorCorrectionLevel; label: string; percentage: number}[] = [
-  {value: 'L', label: '7%', percentage: 7},
-  {value: 'M', label: '15%', percentage: 15},
-  {value: 'Q', label: '25%', percentage: 25},
-  {value: 'H', label: '30%', percentage: 30},
+export const ECL_OPTIONS: {
+  value: ErrorCorrectionLevel;
+  label: string;
+  percentage: number;
+}[] = [
+  { value: 'L', label: '7%', percentage: 7 },
+  { value: 'M', label: '15%', percentage: 15 },
+  { value: 'Q', label: '25%', percentage: 25 },
+  { value: 'H', label: '30%', percentage: 30 },
 ];
 
 export interface QrTypeOption {
@@ -84,3 +88,30 @@ export function eclToPercentage(ecl: ErrorCorrectionLevel): number {
   const option = ECL_OPTIONS.find(opt => opt.value === ecl);
   return option?.percentage ?? 7;
 }
+
+export interface QrStyleConfig {
+  fgColor: string;
+  bgColor: string;
+  size: number;
+}
+
+export const DEFAULT_QR_STYLE: QrStyleConfig = {
+  fgColor: '#000000',
+  bgColor: '#FFFFFF',
+  size: 256,
+};
+
+export const PRESET_COLORS = [
+  '#000000',
+  '#FFFFFF',
+  '#2563EB',
+  '#DC2626',
+  '#16A34A',
+  '#9333EA',
+  '#EA580C',
+  '#0891B2',
+  '#4F46E5',
+  '#BE185D',
+  '#854D0E',
+  '#1E293B',
+];

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -5,17 +5,30 @@ import { getCountryCallingCode, CountryCode } from 'libphonenumber-js';
 import { QrTypeSelector } from '../components/QrTypeSelector';
 import { QrInputForm } from '../components/QrInputForm';
 import { ErrorCorrectionControl } from '../components/ErrorCorrectionControl';
+import { QrStyleEditor } from '../components/QrStyleEditor';
 import { QrDisplay } from '../components/QrDisplay';
 import { QrDecoder } from '../components/QrDecoder';
-import { QrType, ErrorCorrectionLevel, WifiConfig, EmailConfig, SmsConfig } from '../types/qr';
-import { encodeWifi, encodeEmail, encodeSms, encodePhone } from '../utils/encoders';
+import {
+  QrType,
+  ErrorCorrectionLevel,
+  WifiConfig,
+  EmailConfig,
+  SmsConfig,
+  DEFAULT_QR_STYLE,
+} from '../types/qr';
+import {
+  encodeWifi,
+  encodeEmail,
+  encodeSms,
+  encodePhone,
+} from '../utils/encoders';
 
 type Mode = 'create' | 'decode';
 
 export default function Home() {
   // Mode toggle
   const [mode, setMode] = useState<Mode>('create');
-  
+
   // QR type
   const [qrType, setQrType] = useState<QrType>('url');
 
@@ -50,6 +63,12 @@ export default function Home() {
   // QR settings
   const [ecl, setEcl] = useState<ErrorCorrectionLevel>('M');
 
+  // QR style
+  const [fgColor, setFgColor] = useState(DEFAULT_QR_STYLE.fgColor);
+  const [bgColor, setBgColor] = useState(DEFAULT_QR_STYLE.bgColor);
+  const [qrSize, setQrSize] = useState(DEFAULT_QR_STYLE.size);
+  const [showStyleEditor, setShowStyleEditor] = useState(false);
+
   // Compute final QR value
   const qrValue = useMemo(() => {
     switch (qrType) {
@@ -58,9 +77,7 @@ export default function Home() {
         return simpleValue;
       case 'phone':
         return simpleValue
-          ? encodePhone(
-              `+${getCountryCallingCode(phoneCountry)}${simpleValue}`
-            )
+          ? encodePhone(`+${getCountryCallingCode(phoneCountry)}${simpleValue}`)
           : '';
       case 'wifi':
         return wifiConfig.ssid ? encodeWifi(wifiConfig) : '';
@@ -76,7 +93,15 @@ export default function Home() {
       default:
         return '';
     }
-  }, [qrType, simpleValue, wifiConfig, emailConfig, smsConfig, phoneCountry, smsCountry]);
+  }, [
+    qrType,
+    simpleValue,
+    wifiConfig,
+    emailConfig,
+    smsConfig,
+    phoneCountry,
+    smsCountry,
+  ]);
 
   // Handle type change — clear inputs
   const handleTypeChange = (type: QrType) => {
@@ -112,7 +137,8 @@ export default function Home() {
                 QRCrafter
               </h1>
               <p className="text-gray-600 dark:text-gray-400 mt-1">
-                Generate & Decode QR codes • No ads • No trackers • Privacy first
+                Generate & Decode QR codes • No ads • No trackers • Privacy
+                first
               </p>
             </div>
             {/* Mode Toggle */}
@@ -169,6 +195,30 @@ export default function Home() {
                 />
 
                 <ErrorCorrectionControl value={ecl} onChange={setEcl} />
+
+                {/* Style Toggle */}
+                <button
+                  onClick={() => setShowStyleEditor(!showStyleEditor)}
+                  className={`w-full px-4 py-2.5 rounded-lg font-medium transition-colors border ${
+                    showStyleEditor
+                      ? 'bg-primary text-white border-primary'
+                      : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600'
+                  }`}
+                >
+                  Style {showStyleEditor ? '▲' : '▼'}
+                </button>
+
+                {/* Style Editor (collapsible) */}
+                {showStyleEditor && (
+                  <QrStyleEditor
+                    fgColor={fgColor}
+                    bgColor={bgColor}
+                    size={qrSize}
+                    onFgColorChange={setFgColor}
+                    onBgColorChange={setBgColor}
+                    onSizeChange={setQrSize}
+                  />
+                )}
               </div>
 
               {/* Info Card */}
@@ -177,15 +227,21 @@ export default function Home() {
                   🔒 Privacy First
                 </h3>
                 <p className="text-blue-800 dark:text-blue-200 text-sm">
-                  All QR codes are generated locally in your browser. No data is sent to any server.
-                  No ads, no trackers, no URL shorteners.
+                  All QR codes are generated locally in your browser. No data is
+                  sent to any server. No ads, no trackers, no URL shorteners.
                 </p>
               </div>
             </div>
 
             {/* Right Column - QR Display */}
             <div className="flex items-start justify-center lg:pt-6">
-              <QrDisplay value={qrValue} errorCorrectionLevel={ecl} size={256} />
+              <QrDisplay
+                value={qrValue}
+                errorCorrectionLevel={ecl}
+                size={qrSize}
+                fgColor={fgColor}
+                bgColor={bgColor}
+              />
             </div>
           </div>
         ) : (
@@ -193,7 +249,7 @@ export default function Home() {
           <div className="grid lg:grid-cols-2 gap-8">
             {/* Left Column - Decoder */}
             <div>
-              <QrDecoder onDecode={(data) => console.log('Decoded:', data)} />
+              <QrDecoder onDecode={data => console.log('Decoded:', data)} />
             </div>
 
             {/* Right Column - Info */}
@@ -208,16 +264,20 @@ export default function Home() {
                     <div>
                       <h3 className="font-semibold mb-1">Upload a File</h3>
                       <p className="text-gray-600 dark:text-gray-400">
-                        Click the file input to select an image containing a QR code from your device.
+                        Click the file input to select an image containing a QR
+                        code from your device.
                       </p>
                     </div>
                   </div>
                   <div className="flex gap-3">
                     <span className="text-2xl">📋</span>
                     <div>
-                      <h3 className="font-semibold mb-1">Paste from Clipboard</h3>
+                      <h3 className="font-semibold mb-1">
+                        Paste from Clipboard
+                      </h3>
                       <p className="text-gray-600 dark:text-gray-400">
-                        Copy an image to your clipboard, then click the Paste button to decode it.
+                        Copy an image to your clipboard, then click the Paste
+                        button to decode it.
                       </p>
                     </div>
                   </div>
@@ -226,7 +286,8 @@ export default function Home() {
                     <div>
                       <h3 className="font-semibold mb-1">Load from URL</h3>
                       <p className="text-gray-600 dark:text-gray-400">
-                        Enter the URL of an image and click Load to decode the QR code.
+                        Enter the URL of an image and click Load to decode the
+                        QR code.
                       </p>
                     </div>
                   </div>
@@ -239,8 +300,8 @@ export default function Home() {
                   🔒 Privacy First
                 </h3>
                 <p className="text-blue-800 dark:text-blue-200 text-sm">
-                  All QR code decoding happens locally in your browser. Images are never uploaded to any server.
-                  Your privacy is protected.
+                  All QR code decoding happens locally in your browser. Images
+                  are never uploaded to any server. Your privacy is protected.
                 </p>
               </div>
             </div>

--- a/web/src/components/QrDisplay.tsx
+++ b/web/src/components/QrDisplay.tsx
@@ -9,6 +9,8 @@ interface Props {
   value: string;
   errorCorrectionLevel: ErrorCorrectionLevel;
   size?: number;
+  fgColor?: string;
+  bgColor?: string;
 }
 
 interface ErrorBoundaryProps {
@@ -26,7 +28,10 @@ function isCodeLengthOverflow(error: Error): boolean {
   return error.message.toLowerCase().includes('code length overflow');
 }
 
-class QrErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+class QrErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { error: null };
@@ -73,14 +78,20 @@ class QrErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> 
   }
 }
 
-export function QrDisplay({ value, errorCorrectionLevel, size = 256 }: Props) {
+export function QrDisplay({
+  value,
+  errorCorrectionLevel,
+  size = 256,
+  fgColor = '#000000',
+  bgColor = '#FFFFFF',
+}: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const handleDownload = () => {
     if (containerRef.current) {
       const svg = containerRef.current.querySelector('svg');
       if (svg) {
-        downloadQRCode(svg, 'qrcode.png');
+        downloadQRCode(svg, 'qrcode.png', bgColor);
       }
     }
   };
@@ -100,12 +111,22 @@ export function QrDisplay({ value, errorCorrectionLevel, size = 256 }: Props) {
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <QrErrorBoundary size={size} value={value} errorCorrectionLevel={errorCorrectionLevel}>
-        <div ref={containerRef} className="p-4 bg-white rounded-xl shadow-lg">
+      <QrErrorBoundary
+        size={size}
+        value={value}
+        errorCorrectionLevel={errorCorrectionLevel}
+      >
+        <div
+          ref={containerRef}
+          className="p-4 rounded-xl shadow-lg"
+          style={{ backgroundColor: bgColor }}
+        >
           <QRCode
             value={value}
             size={size}
             level={errorCorrectionLevel}
+            fgColor={fgColor}
+            bgColor={bgColor}
           />
         </div>
       </QrErrorBoundary>

--- a/web/src/components/QrStyleEditor.tsx
+++ b/web/src/components/QrStyleEditor.tsx
@@ -74,6 +74,7 @@ function HexInput({
       <input
         type="text"
         value={hex}
+        aria-label="Hex color value"
         onFocus={() => setIsEditing(true)}
         onChange={e => {
           const val = e.target.value.startsWith('#')

--- a/web/src/components/QrStyleEditor.tsx
+++ b/web/src/components/QrStyleEditor.tsx
@@ -32,6 +32,8 @@ function ColorPresetRow({
         <button
           key={`${keyPrefix}-${c}`}
           onClick={() => onSelect(c)}
+          aria-label={`Select color ${c}`}
+          aria-pressed={selected === c}
           className={`w-8 h-8 rounded-full border-2 transition-all hover:scale-110 ${
             selected === c
               ? 'border-blue-500 ring-2 ring-blue-300 dark:ring-blue-700 scale-110'

--- a/web/src/components/QrStyleEditor.tsx
+++ b/web/src/components/QrStyleEditor.tsx
@@ -183,11 +183,15 @@ export function QrStyleEditor({
 
       {/* Size */}
       <div className="space-y-2">
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wide">
+        <label
+          htmlFor="qr-size-slider"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wide"
+        >
           Size
         </label>
         <div className="flex items-center gap-3">
           <input
+            id="qr-size-slider"
             type="range"
             min="120"
             max="400"

--- a/web/src/components/QrStyleEditor.tsx
+++ b/web/src/components/QrStyleEditor.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { PRESET_COLORS } from '../types/qr';
+
+interface Props {
+  fgColor: string;
+  bgColor: string;
+  size: number;
+  onFgColorChange: (color: string) => void;
+  onBgColorChange: (color: string) => void;
+  onSizeChange: (size: number) => void;
+}
+
+const isValidHex = (val: string) =>
+  /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(val);
+
+function ColorPresetRow({
+  colors,
+  selected,
+  onSelect,
+  keyPrefix,
+}: {
+  colors: string[];
+  selected: string;
+  onSelect: (color: string) => void;
+  keyPrefix: string;
+}) {
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {colors.map(c => (
+        <button
+          key={`${keyPrefix}-${c}`}
+          onClick={() => onSelect(c)}
+          className={`w-8 h-8 rounded-full border-2 transition-all hover:scale-110 ${
+            selected === c
+              ? 'border-blue-500 ring-2 ring-blue-300 dark:ring-blue-700 scale-110'
+              : 'border-gray-300 dark:border-gray-600'
+          }`}
+          style={{ backgroundColor: c }}
+          title={c}
+        />
+      ))}
+    </div>
+  );
+}
+
+function HexInput({
+  color,
+  onChange,
+  placeholder,
+}: {
+  color: string;
+  onChange: (color: string) => void;
+  placeholder: string;
+}) {
+  const [hex, setHex] = useState(color);
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setHex(color);
+    }
+  }, [color, isEditing]);
+
+  return (
+    <div className="flex items-center gap-2 mt-2">
+      <div
+        className="w-8 h-8 rounded-lg border border-gray-300 dark:border-gray-600 shrink-0"
+        style={{ backgroundColor: hex && isValidHex(hex) ? hex : color }}
+      />
+      <input
+        type="text"
+        value={hex}
+        onFocus={() => setIsEditing(true)}
+        onChange={e => {
+          const val = e.target.value.startsWith('#')
+            ? e.target.value
+            : `#${e.target.value}`;
+          setHex(val);
+          if (isValidHex(val)) {
+            onChange(val.toUpperCase());
+          }
+        }}
+        onBlur={() => {
+          if (isValidHex(hex)) {
+            onChange(hex.toUpperCase());
+          }
+          setHex(color);
+          setIsEditing(false);
+        }}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            if (isValidHex(hex)) {
+              onChange(hex.toUpperCase());
+            }
+            setHex(color);
+            setIsEditing(false);
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        placeholder={placeholder}
+        maxLength={7}
+        className="flex-1 px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-mono text-sm focus:ring-2 focus:ring-primary focus:border-transparent"
+      />
+    </div>
+  );
+}
+
+export function QrStyleEditor({
+  fgColor,
+  bgColor,
+  size,
+  onFgColorChange,
+  onBgColorChange,
+  onSizeChange,
+}: Props) {
+  const [sizeText, setSizeText] = useState(String(Math.round(size)));
+  const [isEditingSize, setIsEditingSize] = useState(false);
+
+  useEffect(() => {
+    if (!isEditingSize) {
+      setSizeText(String(Math.round(size)));
+    }
+  }, [size, isEditingSize]);
+
+  return (
+    <div className="space-y-5">
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+        Customize Style
+      </h3>
+
+      {/* Foreground Color */}
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wide">
+          Foreground Color
+        </label>
+        <ColorPresetRow
+          colors={PRESET_COLORS.slice(0, 6)}
+          selected={fgColor}
+          onSelect={onFgColorChange}
+          keyPrefix="fg1"
+        />
+        <ColorPresetRow
+          colors={PRESET_COLORS.slice(6)}
+          selected={fgColor}
+          onSelect={onFgColorChange}
+          keyPrefix="fg2"
+        />
+        <HexInput
+          color={fgColor}
+          onChange={onFgColorChange}
+          placeholder="#000000"
+        />
+      </div>
+
+      {/* Background Color */}
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wide">
+          Background Color
+        </label>
+        <ColorPresetRow
+          colors={PRESET_COLORS.slice(0, 6)}
+          selected={bgColor}
+          onSelect={onBgColorChange}
+          keyPrefix="bg1"
+        />
+        <ColorPresetRow
+          colors={PRESET_COLORS.slice(6)}
+          selected={bgColor}
+          onSelect={onBgColorChange}
+          keyPrefix="bg2"
+        />
+        <HexInput
+          color={bgColor}
+          onChange={onBgColorChange}
+          placeholder="#FFFFFF"
+        />
+      </div>
+
+      {/* Size */}
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wide">
+          Size
+        </label>
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min="120"
+            max="400"
+            step="1"
+            value={size}
+            onChange={e => onSizeChange(parseInt(e.target.value, 10))}
+            className="flex-1 h-2 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer accent-primary"
+          />
+          <div className="flex items-center gap-1">
+            <input
+              type="text"
+              value={sizeText}
+              onFocus={() => setIsEditingSize(true)}
+              onChange={e => setSizeText(e.target.value)}
+              onBlur={() => {
+                const num = parseInt(sizeText, 10);
+                if (!isNaN(num) && num >= 120 && num <= 400) {
+                  onSizeChange(num);
+                }
+                setSizeText(String(Math.round(size)));
+                setIsEditingSize(false);
+              }}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  const num = parseInt(sizeText, 10);
+                  if (!isNaN(num) && num >= 120 && num <= 400) {
+                    onSizeChange(num);
+                  }
+                  setSizeText(String(Math.round(size)));
+                  setIsEditingSize(false);
+                  (e.target as HTMLInputElement).blur();
+                }
+              }}
+              maxLength={3}
+              className="w-14 px-2 py-1 text-center rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-primary focus:border-transparent"
+            />
+            <span className="text-sm text-gray-500 dark:text-gray-400 font-medium">
+              px
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/utils/download.ts
+++ b/web/src/utils/download.ts
@@ -1,13 +1,17 @@
 /**
  * Download an SVG element as a PNG image
  */
-export function downloadQRCode(svgElement: SVGSVGElement, filename: string = 'qrcode.png'): void {
+export function downloadQRCode(
+  svgElement: SVGSVGElement,
+  filename: string = 'qrcode.png',
+  bgColor: string = '#FFFFFF',
+): void {
   try {
     // Get the SVG data
     const svgData = new XMLSerializer().serializeToString(svgElement);
     const canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-    
+
     if (!ctx) {
       throw new Error('Failed to get canvas context');
     }
@@ -17,22 +21,22 @@ export function downloadQRCode(svgElement: SVGSVGElement, filename: string = 'qr
     const svgRect = svgElement.getBoundingClientRect();
     canvas.width = svgRect.width * scale;
     canvas.height = svgRect.height * scale;
-    
+
     // Create an image from SVG
     const img = new Image();
     const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
     const url = URL.createObjectURL(blob);
-    
+
     img.onload = () => {
-      // Fill with white background
-      ctx.fillStyle = 'white';
+      // Fill with background color
+      ctx.fillStyle = bgColor;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
-      
+
       // Draw the image scaled up
       ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-      
+
       // Convert to PNG and download
-      canvas.toBlob((pngBlob) => {
+      canvas.toBlob(pngBlob => {
         if (pngBlob) {
           const pngUrl = URL.createObjectURL(pngBlob);
           const link = document.createElement('a');
@@ -41,15 +45,15 @@ export function downloadQRCode(svgElement: SVGSVGElement, filename: string = 'qr
           document.body.appendChild(link);
           link.click();
           document.body.removeChild(link);
-          
+
           // Cleanup
           URL.revokeObjectURL(pngUrl);
         }
       }, 'image/png');
-      
+
       URL.revokeObjectURL(url);
     };
-    
+
     img.src = url;
   } catch (error) {
     console.error('Failed to download QR code:', error);


### PR DESCRIPTION
## Summary

- Ports the style editing feature from the mobile app to the web app, adding a collapsible **Style** panel with foreground/background color customization (12 preset colors + hex input) and a size slider (120-400px)
- Updates `QrDisplay` to pass `fgColor`/`bgColor` to `react-qr-code` and the PNG download utility to respect the custom background color
- Adds shared `QrStyleConfig` type, `DEFAULT_QR_STYLE`, and `PRESET_COLORS` to `shared/qr.ts` for cross-platform reuse