### PR TITLE
fix: release instruction consistency -- version naming, annotated tags, explicit push

### DIFF
--- a/.github/GIT_WORKFLOW.md
+++ b/.github/GIT_WORKFLOW.md
@@ -137,7 +137,7 @@ npm run version:sync           # Align version across package.json, web/package.
 git add -A
 git commit -m "chore(release): bump version to 1.4.0"
 git tag -a v1.4.0 -m "Release v1.4.0"
-git push origin master --tags
+git push origin master refs/tags/v1.4.0
 ```
 
 ### What happens on tag push
@@ -176,5 +176,5 @@ git push -u origin feature/my-feature
 npm run version:sync
 git add -A && git commit -m "chore(release): bump version to 1.4.0"
 git tag -a v1.4.0 -m "Release v1.4.0"
-git push origin master --tags
+git push origin master refs/tags/v1.4.0
 ```

--- a/.github/GIT_WORKFLOW.md
+++ b/.github/GIT_WORKFLOW.md
@@ -134,10 +134,10 @@ Always use **annotated tags** to preserve release metadata:
 
 ```bash
 npm run version:sync           # Align version across package.json, web/package.json, tauri.conf.json
-git add -A
+git add package.json package-lock.json web/package.json web/package-lock.json web/src-tauri/tauri.conf.json
 git commit -m "chore(release): bump version to 1.4.0"
 git tag -a v1.4.0 -m "Release v1.4.0"
-git push origin master refs/tags/v1.4.0
+git push origin refs/heads/master refs/tags/v1.4.0
 ```
 
 ### What happens on tag push
@@ -174,7 +174,8 @@ git push -u origin feature/my-feature
 
 # Release
 npm run version:sync
-git add -A && git commit -m "chore(release): bump version to 1.4.0"
+git add package.json package-lock.json web/package.json web/package-lock.json web/src-tauri/tauri.conf.json
+git commit -m "chore(release): bump version to 1.4.0"
 git tag -a v1.4.0 -m "Release v1.4.0"
-git push origin master refs/tags/v1.4.0
+git push origin refs/heads/master refs/tags/v1.4.0
 ```

--- a/.github/GIT_WORKFLOW.md
+++ b/.github/GIT_WORKFLOW.md
@@ -133,7 +133,8 @@ Releases are triggered by pushing a version tag to `master`.
 Always use **annotated tags** to preserve release metadata:
 
 ```bash
-npm run version:sync           # Align version across package.json, web/package.json, tauri.conf.json
+npm version 1.4.0 --no-git-tag-version   # Bump root package.json version
+npm run version:sync                      # Propagate to web/package.json, tauri.conf.json, lockfiles
 git add package.json package-lock.json web/package.json web/package-lock.json web/src-tauri/tauri.conf.json
 git commit -m "chore(release): bump version to 1.4.0"
 git tag -a v1.4.0 -m "Release v1.4.0"
@@ -173,6 +174,7 @@ git push -u origin feature/my-feature
 # Open PR against master
 
 # Release
+npm version 1.4.0 --no-git-tag-version
 npm run version:sync
 git add package.json package-lock.json web/package.json web/package-lock.json web/src-tauri/tauri.conf.json
 git commit -m "chore(release): bump version to 1.4.0"

--- a/.github/GIT_WORKFLOW.md
+++ b/.github/GIT_WORKFLOW.md
@@ -130,11 +130,13 @@ Releases are triggered by pushing a version tag to `master`.
 
 ### Tagging
 
+Always use **annotated tags** to preserve release metadata:
+
 ```bash
 npm run version:sync           # Align version across package.json, web/package.json, tauri.conf.json
 git add -A
 git commit -m "chore(release): bump version to 1.4.0"
-git tag v1.4.0
+git tag -a v1.4.0 -m "Release v1.4.0"
 git push origin master --tags
 ```
 
@@ -173,6 +175,6 @@ git push -u origin feature/my-feature
 # Release
 npm run version:sync
 git add -A && git commit -m "chore(release): bump version to 1.4.0"
-git tag v1.4.0
+git tag -a v1.4.0 -m "Release v1.4.0"
 git push origin master --tags
 ```

--- a/.github/instructions/release-master.instructions.md
+++ b/.github/instructions/release-master.instructions.md
@@ -179,10 +179,10 @@ Tag format is always `v` prefix + full semver: `v1.6.0`, `v2.0.0`, etc. Always u
 
 ## Step 10: Push
 
-Push the commit and tag together. Use explicit ref to avoid ambiguity with the legacy `master` tag in this repo:
+Push the commit and the specific release tag together. Use an explicit branch ref to avoid ambiguity with the legacy `master` tag, and push only the new tag so unrelated local tags are not published:
 
 ```bash
-git push origin refs/heads/master --tags
+git push origin refs/heads/master refs/tags/v<NEW_VERSION>
 ```
 
 ---

--- a/.github/instructions/release-master.instructions.md
+++ b/.github/instructions/release-master.instructions.md
@@ -97,15 +97,15 @@ Calculate the new version from `LAST_TAG`.
 
 Use these representations consistently throughout all remaining steps:
 
-- `LAST_TAG` is the git tag, including the `v` prefix (e.g., `v1.5.0`)
-- `NEW_VERSION` is the plain semver version, **without** the `v` prefix (e.g., `1.6.0`)
-- `NEW_TAG` is the git tag form: `v<NEW_VERSION>` (e.g., `v1.6.0`)
+- `LAST_TAG` is the existing git tag, including the `v` prefix (e.g., `v1.5.0`)
+- `NEW_VERSION` is the new plain semver version, **without** the `v` prefix (e.g., `1.6.0`)
+- When a later command needs the git tag form for the new release, use `v<NEW_VERSION>` explicitly
 
 Examples:
 
-- `v1.5.0` + MAJOR → `NEW_VERSION=2.0.0`, `NEW_TAG=v2.0.0`
-- `v1.5.0` + MINOR → `NEW_VERSION=1.6.0`, `NEW_TAG=v1.6.0`
-- `v1.5.0` + PATCH → `NEW_VERSION=1.5.1`, `NEW_TAG=v1.5.1`
+- `v1.5.0` + MAJOR → `NEW_VERSION=2.0.0` and the new tag will be `v2.0.0`
+- `v1.5.0` + MINOR → `NEW_VERSION=1.6.0` and the new tag will be `v1.6.0`
+- `v1.5.0` + PATCH → `NEW_VERSION=1.5.1` and the new tag will be `v1.5.1`
 
 ---
 

--- a/.github/instructions/release-master.instructions.md
+++ b/.github/instructions/release-master.instructions.md
@@ -170,10 +170,10 @@ Do NOT use `git add -A`. Only stage the 5 manifest files listed above.
 Create an **annotated** tag to preserve release metadata:
 
 ```bash
-git tag -a v<NEW_VERSION> -m "Release v<NEW_VERSION>"
+git tag -a <NEW_TAG> -m "Release <NEW_TAG>"
 ```
 
-Tag format is always `v` prefix + full semver: `v1.6.0`, `v2.0.0`, etc. Always use annotated tags (`-a`), never lightweight tags.
+Always use annotated tags (`-a`), never lightweight tags.
 
 ---
 
@@ -182,7 +182,7 @@ Tag format is always `v` prefix + full semver: `v1.6.0`, `v2.0.0`, etc. Always u
 Push the commit and the specific release tag together. Use an explicit branch ref to avoid ambiguity with the legacy `master` tag, and push only the new tag so unrelated local tags are not published:
 
 ```bash
-git push origin refs/heads/master refs/tags/v<NEW_VERSION>
+git push origin refs/heads/master refs/tags/<NEW_TAG>
 ```
 
 ---
@@ -192,7 +192,7 @@ git push origin refs/heads/master refs/tags/v<NEW_VERSION>
 After pushing, inform the user:
 
 1. The version bump commit hash
-2. The tag that was pushed (`v<NEW_VERSION>`)
+2. The tag that was pushed (`<NEW_TAG>`)
 3. That the CI release pipeline has been triggered
 4. Link to the GitHub Actions run: `https://github.com/CT4nk3r/QRCrafter/actions`
 

--- a/.github/instructions/release-master.instructions.md
+++ b/.github/instructions/release-master.instructions.md
@@ -93,11 +93,19 @@ Apply SemVer rules:
 2. Else if ANY commit is a `feat` → **MINOR** bump
 3. Else → **PATCH** bump
 
-Calculate the new version from `LAST_TAG`:
+Calculate the new version from `LAST_TAG`.
 
-- `v1.5.0` + MAJOR → `v2.0.0`
-- `v1.5.0` + MINOR → `v1.6.0`
-- `v1.5.0` + PATCH → `v1.5.1`
+Use these representations consistently throughout all remaining steps:
+
+- `LAST_TAG` is the git tag, including the `v` prefix (e.g., `v1.5.0`)
+- `NEW_VERSION` is the plain semver version, **without** the `v` prefix (e.g., `1.6.0`)
+- `NEW_TAG` is the git tag form: `v<NEW_VERSION>` (e.g., `v1.6.0`)
+
+Examples:
+
+- `v1.5.0` + MAJOR → `NEW_VERSION=2.0.0`, `NEW_TAG=v2.0.0`
+- `v1.5.0` + MINOR → `NEW_VERSION=1.6.0`, `NEW_TAG=v1.6.0`
+- `v1.5.0` + PATCH → `NEW_VERSION=1.5.1`, `NEW_TAG=v1.5.1`
 
 ---
 
@@ -159,11 +167,13 @@ Do NOT use `git add -A`. Only stage the 5 manifest files listed above.
 
 ## Step 9: Create the Tag
 
+Create an **annotated** tag to preserve release metadata:
+
 ```bash
-git tag v<NEW_VERSION>
+git tag -a v<NEW_VERSION> -m "Release v<NEW_VERSION>"
 ```
 
-Tag format is always `v` prefix + full semver: `v1.6.0`, `v2.0.0`, etc.
+Tag format is always `v` prefix + full semver: `v1.6.0`, `v2.0.0`, etc. Always use annotated tags (`-a`), never lightweight tags.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes two inconsistencies in the release-master instructions and GIT_WORKFLOW.md:

- **Version variable naming**: Define three clear representations (`LAST_TAG=v1.5.0`, `NEW_VERSION=1.6.0`, `NEW_TAG=v1.6.0`) to avoid `v` prefix confusion between `npm version` (no prefix) and `git tag` (prefix)
- **Annotated tags**: Switch from lightweight `git tag` to `git tag -a` to match existing release scripts and preserve release metadata
- **Explicit tag push**: Replace `git push --tags` (pushes all local tags) with `git push origin refs/heads/master refs/tags/v<VERSION>` to only push the intended release tag